### PR TITLE
Add support for multiple windows

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSUserActivityTypes</key>
+    <array>
+	    <string>xyz.kebo.DevToysForiPad.newWindow</string>
+    </array>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
 </dict>

--- a/Sources/DevToysApp/Components/Buttons/OpenInNewWindowButton.swift
+++ b/Sources/DevToysApp/Components/Buttons/OpenInNewWindowButton.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct OpenInNewWindowButton {
+    let tool: Tool
+}
+
+extension OpenInNewWindowButton: View {
+    var body: some View {
+        Button {
+            let activity = NSUserActivity(
+                activityType: "xyz.kebo.DevToysForiPad.newWindow"
+            )
+            try! activity.setTypedPayload(
+                NewWindowActivityPayload(tool: self.tool)
+            )
+            let options = UIWindowScene.ActivationRequestOptions()
+            options.preferredPresentationStyle = .prominent
+            UIApplication.shared.requestSceneSessionActivation(
+                nil,
+                userActivity: activity,
+                options: options
+            )
+        } label: {
+            Label("Open in New Window", systemImage: "rectangle.badge.plus")
+        }
+    }
+}
+
+struct OpenInNewWindowButton_Previews: PreviewProvider {
+    static var previews: some View {
+        OpenInNewWindowButton(tool: .jsonYAMLConverter)
+            .previewPresets()
+    }
+}

--- a/Sources/DevToysApp/ContentView.swift
+++ b/Sources/DevToysApp/ContentView.swift
@@ -53,6 +53,10 @@ extension ContentView: View {
             text: self.$searchQuery,
             prompt: "Type to search for tools..."
         )
+        .onContinueUserActivity("xyz.kebo.DevToysForiPad.newWindow") {
+            let payload = try? $0.typedPayload(NewWindowActivityPayload.self)
+            self.selection = payload?.tool
+        }
     }
 }
 

--- a/Sources/DevToysApp/ContentView.swift
+++ b/Sources/DevToysApp/ContentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ContentView {
+    @StateObject private var state = AppState()
     @State var selection: Tool?
     @State private var searchQuery = ""
 }
@@ -9,10 +10,12 @@ extension ContentView: View {
     var body: some View {
         NavigationView {
             Sidebar(
+                state: self.state,
                 selection: self.$selection,
                 searchQuery: self.searchQuery
             )
             AllToolsView(
+                state: self.state,
                 selection: self.$selection,
                 searchQuery: self.searchQuery
             )
@@ -27,7 +30,6 @@ extension ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
-            .environmentObject(AppState())
             .previewPresets()
     }
 }

--- a/Sources/DevToysApp/ContentView.swift
+++ b/Sources/DevToysApp/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ContentView {
     @StateObject private var state = AppState()
-    @State var selection: Tool?
+    @SceneStorage("selectedTool") private var selection: Tool?
     @State private var searchQuery = ""
 }
 
@@ -14,11 +14,40 @@ extension ContentView: View {
                 selection: self.$selection,
                 searchQuery: self.searchQuery
             )
-            AllToolsView(
-                state: self.state,
-                selection: self.$selection,
-                searchQuery: self.searchQuery
-            )
+            switch self.selection {
+            case nil:
+                AllToolsView(
+                    state: self.state,
+                    selection: self.$selection,
+                    searchQuery: self.searchQuery
+                )
+            case .base64Coder:
+                Base64CoderView(state: self.state.base64CoderViewState)
+            case .hashGenerator:
+                HashGeneratorView(state: self.state.hashGeneratorViewState)
+            case .htmlCoder:
+                HTMLCoderView(state: self.state.htmlCoderViewState)
+            case .jsonFormatter:
+                JSONFormatterView(state: self.state.jsonFormatterViewState)
+            case .jsonYAMLConverter:
+                JSONYAMLConverterView()
+            case .jwtDecoder:
+                JWTDecoderView(state: self.state.jwtDecoderViewState)
+            case .loremIpsumGenerator:
+                LoremIpsumGeneratorView(
+                    state: self.state.loremIpsumGeneratorViewState
+                )
+            case .markdownPreview:
+                MarkdownPreviewView(state: self.state.markdownPreviewViewState)
+            case .numberBaseConverter:
+                NumberBaseConverterView(
+                    state: self.state.numberBaseConverterViewState
+                )
+            case .urlCoder:
+                URLCoderView(state: self.state.urlCoderViewState)
+            case .uuidGenerator:
+                UUIDGeneratorView(state: self.state.uuidGeneratorViewState)
+            }
         }
         .searchable(
             text: self.$searchQuery,

--- a/Sources/DevToysApp/DevToysApp.swift
+++ b/Sources/DevToysApp/DevToysApp.swift
@@ -15,7 +15,6 @@ extension DevToysApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(AppState())
         }
     }
 }

--- a/Sources/DevToysApp/Models/NewWindowActivityPayload.swift
+++ b/Sources/DevToysApp/Models/NewWindowActivityPayload.swift
@@ -1,0 +1,5 @@
+struct NewWindowActivityPayload {
+    var tool: Tool
+}
+
+extension NewWindowActivityPayload: Codable {}

--- a/Sources/DevToysApp/Pages/AllToolsView.swift
+++ b/Sources/DevToysApp/Pages/AllToolsView.swift
@@ -42,7 +42,7 @@ struct AllToolsView {
     ]
 
     @Environment(\.isSearching) private var isSearchMode
-    @EnvironmentObject private var state: AppState
+    @ObservedObject var state: AppState
     @Binding var selection: Tool?
     let searchQuery: String
 
@@ -105,8 +105,11 @@ extension AllToolsView: View {
 
 struct AllToolsView_Previews: PreviewProvider {
     static var previews: some View {
-        AllToolsView(selection: .constant(nil), searchQuery: "")
-            .environmentObject(AppState())
-            .previewPresets()
+        AllToolsView(
+            state: .init(),
+            selection: .constant(nil),
+            searchQuery: ""
+        )
+        .previewPresets()
     }
 }

--- a/Sources/DevToysApp/Pages/AllToolsView.swift
+++ b/Sources/DevToysApp/Pages/AllToolsView.swift
@@ -79,27 +79,47 @@ extension AllToolsView: View {
     }
 
     private func button(for tool: Tool) -> some View {
-        let strings = tool.strings
-        return Button {
+        Button {
             self.selection = tool
         } label: {
-            Label {
-                Text(LocalizedStringKey(strings.longTitle))
-                Text(LocalizedStringKey(strings.description))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } icon: {
-                if strings.boldIcon {
-                    Image(systemName: strings.iconName)
-                        .font(.system(size: 50).bold())
-                } else {
-                    Image(systemName: strings.iconName)
-                }
-            }
-            .labelStyle(AllToolsLabelStyle())
+            self.buttonLabel(for: tool)
         }
         .foregroundStyle(.primary)
         .hoverEffect()
+        .onDrag {
+            let activity = NSUserActivity(
+                activityType: "xyz.kebo.DevToysForiPad.newWindow"
+            )
+            try! activity.setTypedPayload(
+                NewWindowActivityPayload(tool: tool)
+            )
+            return .init(object: activity)
+        } preview: {
+            self.buttonLabel(for: tool)
+        }
+        .contextMenu {
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                OpenInNewWindowButton(tool: tool)
+            }
+        }
+    }
+
+    private func buttonLabel(for tool: Tool) -> some View {
+        let strings = tool.strings
+        return Label {
+            Text(LocalizedStringKey(strings.longTitle))
+            Text(LocalizedStringKey(strings.description))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } icon: {
+            if strings.boldIcon {
+                Image(systemName: strings.iconName)
+                    .font(.system(size: 50).bold())
+            } else {
+                Image(systemName: strings.iconName)
+            }
+        }
+        .labelStyle(AllToolsLabelStyle())
     }
 }
 

--- a/Sources/DevToysApp/Sidebar.swift
+++ b/Sources/DevToysApp/Sidebar.swift
@@ -106,6 +106,20 @@ extension Sidebar: View {
                 }
             }
         }
+        .onDrag {
+            let activity = NSUserActivity(
+                activityType: "xyz.kebo.DevToysForiPad.newWindow"
+            )
+            try! activity.setTypedPayload(
+                NewWindowActivityPayload(tool: tool)
+            )
+            return .init(object: activity)
+        }
+        .contextMenu {
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                OpenInNewWindowButton(tool: tool)
+            }
+        }
     }
 
     @ViewBuilder private func destination(for tool: Tool) -> some View {

--- a/Sources/DevToysApp/Sidebar.swift
+++ b/Sources/DevToysApp/Sidebar.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct Sidebar {
     @Environment(\.isSearching) private var isSearchMode
-    @EnvironmentObject private var state: AppState
+    @ObservedObject var state: AppState
     @Binding var selection: Tool?
     let searchQuery: String
 
@@ -43,6 +43,7 @@ extension Sidebar: View {
     @ViewBuilder private var normalRows: some View {
         NavigationLink {
             AllToolsView(
+                state: self.state,
                 selection: self.$selection,
                 searchQuery: self.searchQuery
             )
@@ -141,8 +142,7 @@ extension Sidebar: View {
 
 struct Sidebar_Previews: PreviewProvider {
     static var previews: some View {
-        Sidebar(selection: .constant(nil), searchQuery: "")
-            .environmentObject(AppState())
+        Sidebar(state: .init(), selection: .constant(nil), searchQuery: "")
             .previewPresets()
     }
 }

--- a/Sources/DevToysApp/Tool.swift
+++ b/Sources/DevToysApp/Tool.swift
@@ -1,4 +1,4 @@
-enum Tool {
+enum Tool: String {
     case base64Coder
     case hashGenerator
     case htmlCoder

--- a/Sources/DevToysApp/Tool.swift
+++ b/Sources/DevToysApp/Tool.swift
@@ -132,3 +132,5 @@ extension Tool: Identifiable {
 }
 
 extension Tool: CaseIterable {}
+
+extension Tool: Codable {}


### PR DESCRIPTION
fixes #7

Changes:

- Added support for scene state restoration
- Added support for opening a tool in a new window by tapping the "Open in New Window" menu and using drag and drop


https://user-images.githubusercontent.com/601636/167305127-50f160f6-8ed7-469f-a07b-8f11efbdbba8.MOV

Note:

These features don't work on Swift Playgrounds' app preview. To test them, there are two options:

1. Use Xcode to install the app on the device
2. Upload the app to TestFlight and install it on the device

References:

- https://www.michaelfcollins3.me/posts/2021/01/creating-multiple-scenes-in-a-swiftui-app/