### PR TITLE
Sync search queries between on Sidebar and on AllToolsView

### DIFF
--- a/Sources/DevToysApp/ContentView.swift
+++ b/Sources/DevToysApp/ContentView.swift
@@ -3,17 +3,18 @@ import SwiftUI
 struct ContentView {
     @StateObject private var state = AppState()
     @SceneStorage("selectedTool") private var selection: Tool?
+    @State private var searchQuery = ""
 }
 
 extension ContentView: View {
     var body: some View {
         NavigationView {
-            Sidebar(state: self.state, selection: self.$selection)
+            Sidebar(state: self.state, selection: self.$selection, searchQuery: self.$searchQuery)
             if let tool = self.selection {
                 // If the sidebar is collapsed from the beginning, the transition using NavigationLink's selection doesn't fire until the sidebar is shown once. The following code is a workaround for that.
                 tool.page(state: self.state)
             } else {
-                AllToolsView(state: self.state, selection: self.$selection)
+                AllToolsView(state: self.state, selection: self.$selection, searchQuery: self.$searchQuery)
             }
         }
         .onContinueUserActivity("xyz.kebo.DevToysForiPad.newWindow") {

--- a/Sources/DevToysApp/Pages/AllToolsView.swift
+++ b/Sources/DevToysApp/Pages/AllToolsView.swift
@@ -43,7 +43,7 @@ struct AllToolsView {
 
     @ObservedObject var state: AppState
     @Binding var selection: Tool?
-    @State private var searchQuery = ""
+    @Binding var searchQuery: String
 
     private var isSearching: Bool {
         !self.searchQuery.isEmpty
@@ -126,7 +126,7 @@ extension AllToolsView: View {
 struct AllToolsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            AllToolsView(state: .init(), selection: .constant(nil))
+            AllToolsView(state: .init(), selection: .constant(nil), searchQuery: .constant(""))
         }
         .navigationViewStyle(.stack)
         .previewPresets()

--- a/Sources/DevToysApp/Sidebar.swift
+++ b/Sources/DevToysApp/Sidebar.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct Sidebar {
     @ObservedObject var state: AppState
     @Binding var selection: Tool?
-    @State private var searchQuery = ""
+    @Binding var searchQuery: String
 
     private var isSearching: Bool {
         !self.searchQuery.isEmpty
@@ -43,7 +43,7 @@ extension Sidebar: View {
 
     @ViewBuilder private var normalRows: some View {
         NavigationLink {
-            AllToolsView(state: self.state, selection: self.$selection)
+            AllToolsView(state: self.state, selection: self.$selection, searchQuery: self.$searchQuery)
         } label: {
             Label("All tools", systemImage: "house")
         }
@@ -96,7 +96,7 @@ extension Sidebar: View {
 struct Sidebar_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            Sidebar(state: .init(), selection: .constant(nil))
+            Sidebar(state: .init(), selection: .constant(nil), searchQuery: .constant(""))
         }
         .previewPresets()
     }


### PR DESCRIPTION
Currently, `.searchable` modifiers are attached to both `Sidebar` and `AllToolsView` to support both iPhone (single column) and iPad (2 columns). However, the search queries for both are independent. This is inconvenient, so I am going to change it so that they are synchronized.