### PR TITLE
Add JSON <> YAML Converter (#1)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -73,6 +73,15 @@
       }
     },
     {
+      "identity" : "swift-uniyaml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kkk669/swift-uniyaml",
+      "state" : {
+        "branch" : "origin/issues/1",
+        "revision" : "3fac3e310bbf3e10a48b1dc3639cc0e7e6445247"
+      }
+    },
+    {
       "identity" : "swiftjsonformatter",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luin/SwiftJSONFormatter",

--- a/Package.resolved
+++ b/Package.resolved
@@ -78,7 +78,7 @@
       "location" : "https://github.com/kkk669/swift-uniyaml",
       "state" : {
         "branch" : "origin/issues/1",
-        "revision" : "3fac3e310bbf3e10a48b1dc3639cc0e7e6445247"
+        "revision" : "acce8c01b2fed1aa87bfb960ebe09caaae3c18d0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .package(url: "https://github.com/Losiowaty/PlaygroundTester", "0.3.1"..<"0.4.0"),
         .package(url: "https://github.com/lukaskubanek/LoremSwiftum", "2.2.1"..<"2.3.0"),
         .package(url: "https://github.com/JohnSundell/Ink", "0.5.1"..<"0.6.0"),
+        .package(url: "https://github.com/kkk669/swift-uniyaml", branch: "origin/issues/1"),
     ],
     targets: [
         .executableTarget(
@@ -32,6 +33,7 @@ let package = Package(
                 .product(name: "PlaygroundTester", package: "PlaygroundTester"),
                 .product(name: "LoremSwiftum", package: "LoremSwiftum"),
                 .product(name: "Ink", package: "Ink"),
+                .product(name: "UniYAML", package: "swift-uniyaml"),
             ],
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This app is a SwiftUI reimplementation of [DevToys](https://devtoys.app), a Swis
 ## Features
 
 - Converters
-  - [ ] JSON <> YAML
+  - [x] JSON <> YAML
+    - Partial support
   - [x] Number Base
   - [x] Unix Timestamp
 - Encoders / Decoders

--- a/Sources/DevToysApp/AppState.swift
+++ b/Sources/DevToysApp/AppState.swift
@@ -13,6 +13,7 @@ final class AppState {
     let loremIpsumGeneratorViewState = LoremIpsumGeneratorViewState()
     let markdownPreviewViewState = MarkdownPreviewViewState()
     let timestampConverterViewState = TimestampConverterViewState()
+    let jsonYAMLConverterViewState = JSONYAMLConverterViewState()
 }
 
 extension AppState: ObservableObject {}

--- a/Sources/DevToysApp/Models/Converters/JSONYAMLConversionMode.swift
+++ b/Sources/DevToysApp/Models/Converters/JSONYAMLConversionMode.swift
@@ -1,0 +1,15 @@
+enum JSONYAMLConversionMode {
+    case yamlToJSON
+    case jsonToYAML
+}
+
+extension JSONYAMLConversionMode: CaseIterable {}
+
+extension JSONYAMLConversionMode: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .yamlToJSON: return "YAML to JSON"
+        case .jsonToYAML: return "JSON to YAML"
+        }
+    }
+}

--- a/Sources/DevToysApp/Models/Converters/JSONYAMLConverter.swift
+++ b/Sources/DevToysApp/Models/Converters/JSONYAMLConverter.swift
@@ -1,0 +1,486 @@
+import Foundation
+import UniYAML
+
+struct JSONYAMLConverter {
+    static func convert(
+        _ input: String,
+        mode: JSONYAMLConversionMode
+    ) throws -> String {
+        let inputObject = try UniYAML.decode(input)
+        switch mode {
+        case .yamlToJSON:
+            let output = try UniYAML.encode(inputObject, with: .json)
+            let json = try JSONSerialization.jsonObject(with: Data(output.utf8))
+            return String(
+                data: try JSONSerialization.data(
+                    withJSONObject: json,
+                    options: [.prettyPrinted, .sortedKeys]
+                ),
+                encoding: .utf8
+            ) ?? ""
+        case .jsonToYAML:
+            return try UniYAML.encode(inputObject, with: .yaml)
+        }
+    }
+}
+
+#if TESTING_ENABLED
+    import Foundation
+    import PlaygroundTester
+
+    @objcMembers
+    final class JSONYAMLConverterTests: TestCase {
+        func testYAMLCommentsToJSON() throws {
+            let yaml = #"""
+                # A single line comment example
+
+                # block level comment example
+                # comment line 1
+                # comment line 2
+                # comment line 3
+                """#
+            AssertEqual(
+                "",
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLIntegerToJSON() throws {
+            let yaml = "n1: 1"
+            let json = #"""
+                {
+                  "n1" : 1
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLFloatToJSON() throws {
+            let yaml = "n2: 1.234"
+            let json = #"""
+                {
+                  "n2" : 1.234
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLStringToJSON() throws {
+            let yaml = #"""
+                s1: 'abc'
+                s2: "abc"
+                s3: abc
+                """#
+            let json = #"""
+                {
+                  "s1" : "abc",
+                  "s2" : "abc",
+                  "s3" : "abc"
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLMultilineStringsToJSON() throws {
+            let yaml = #"""
+                description: |
+                  hello
+                  world
+                """#
+            let json = #"""
+                {
+                  "description" : "hello\nworld\n"
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLFoldedStringsToJSON() throws {
+            let yaml = #"""
+                description: >
+                  hello
+                  world
+                """#
+            let json = #"""
+                {
+                  "description" : "hello world\n"
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLBooleanToJSON() throws {
+            let yaml = "b: false"
+            let json = #"""
+                {
+                  "b" : false
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLDateToJSON() throws {
+            let yaml = "d: 2015-04-05"
+            let json = #"""
+                {
+                  "d" : "2015-04-05"
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLInheritanceToJSON() throws {
+            let yaml = #"""
+                parent: &defaults
+                  a: 2
+                  b: 3
+
+                child:
+                  <<: *defaults
+                  b: 4
+                """#
+            let json = #"""
+                {
+                  "child" : {
+                    "a" : 2,
+                    "b" : 4
+                  },
+                  "parent" : {
+                    "a" : 2,
+                    "b" : 3
+                  }
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLVariablesToJSON() throws {
+            let yaml = #"""
+                some_thing: &VAR_NAME foobar
+                other_thing: *VAR_NAME
+                """#
+            let json = #"""
+                {
+                  "other_thing" : "foobar",
+                  "some_thing" : "foobar"
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLReferenceToJSON() throws {
+            let yaml = #"""
+                values: &ref
+                  - Will be
+                  - reused below
+                  
+                other_values:
+                  i_am_ref: *ref
+                """#
+            let json = #"""
+                {
+                  "other_values" : {
+                    "i_am_ref" : [
+                      "Will be",
+                      "reused below"
+                    ]
+                  },
+                  "values" : [
+                    "Will be",
+                    "reused below"
+                  ]
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLSequenceToJSON() throws {
+            let yaml = #"""
+                - Mark McGwire
+                - Sammy Sosa
+                - Ken Griffey
+                """#
+            let json = #"""
+                [
+                  "Mark McGwire",
+                  "Sammy Sosa",
+                  "Ken Griffey"
+                ]
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLMappingToJSON() throws {
+            let yaml = #"""
+                hr:  65       # Home runs
+                avg: 0.278    # Batting average
+                rbi: 147      # Runs Batted In
+                """#
+            let json = #"""
+                {
+                  "avg" : 0.278,
+                  "hr" : 65,
+                  "rbi" : 147
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLMappingToSequencesToJSON() throws {
+            let yaml = #"""
+                attributes:
+                  - a1
+                  - a2
+                methods: [getter, setter]
+                """#
+            let json = #"""
+                {
+                  "attributes" : [
+                    "a1",
+                    "a2"
+                  ],
+                  "methods" : [
+                    "getter",
+                    "setter"
+                  ]
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLSequenceOfMappingsToJSON() throws {
+            let yaml = #"""
+                children:
+                  - name: Jimmy Smith
+                    age: 15
+                  - name: Jimmy Smith
+                    age: 15
+                  -
+                    name: Sammy Sosa
+                    age: 12
+                """#
+            let json = #"""
+                {
+                  "children" : [
+                    {
+                      "age" : 15,
+                      "name" : "Jimmy Smith"
+                    },
+                    {
+                      "age" : 15,
+                      "name" : "Jimmy Smith"
+                    },
+                    {
+                      "age" : 12,
+                      "name" : "Sammy Sosa"
+                    }
+                  ]
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLSequenceOfSequencesToJSON() throws {
+            let yaml = #"""
+                my_sequences:
+                  - [1, 2, 3]
+                  - [4, 5, 6]
+                  -  
+                    - 7
+                    - 8
+                    - 9
+                    - 0
+                """#
+            let json = #"""
+                {
+                  "my_sequences" : [
+                    [
+                      1,
+                      2,
+                      3
+                    ],
+                    [
+                      4,
+                      5,
+                      6
+                    ],
+                    [
+                      7,
+                      8,
+                      9,
+                      0
+                    ]
+                  ]
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLMappingOfMappingsToJSON() throws {
+            let yaml = #"""
+                Mark McGwire: {hr: 65, avg: 0.278}
+                Sammy Sosa: {
+                    hr: 63,
+                    avg: 0.288
+                  }
+                """#
+            let json = #"""
+                {
+                  "Mark McGwire" : {
+                    "avg" : 0.278,
+                    "hr" : 65
+                  },
+                  "Sammy Sosa" : {
+                    "avg" : 0.288,
+                    "hr" : 63
+                  }
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLNestedCollectionsToJSON() throws {
+            let yaml = #"""
+                Jack:
+                  id: 1
+                  name: Franc
+                  salary: 25000
+                  hobby:
+                    - a
+                    - b
+                  location: {country: "A", city: "A-A"}
+                """#
+            let json = #"""
+                {
+                  "Jack" : {
+                    "hobby" : [
+                      "a",
+                      "b"
+                    ],
+                    "id" : 1,
+                    "location" : {
+                      "country" : "A",
+                      "city" : "A-A"
+                    },
+                    "name" : "Franc",
+                    "salary" : 25000
+                  }
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLUnorderedSetsToJSON() throws {
+            let yaml = #"""
+                set1: !!set
+                  ? one
+                  ? two
+                set2: !!set {'one', "two"}
+                """#
+            let json = #"""
+                {
+                  "set1" : {
+                    "one" : null,
+                    "two" : null
+                  },
+                  "set2" : {
+                    "one" : null,
+                    "two" : null
+                  }
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testYAMLOrderedMappingsToJSON() throws {
+            let yaml = #"""
+                ordered: !!omap
+                - Mark McGwire: 65
+                - Sammy Sosa: 63
+                - Ken Griffy: 58
+                """#
+            let json = #"""
+                {
+                  "ordered" : [
+                    {
+                      "Mark McGwire" : 65
+                    },
+                    {
+                      "Sammy Sosa" : 63
+                    },
+                    {
+                      "Ken Griffy" : 58
+                    }
+                  ]
+                }
+                """#
+            AssertEqual(
+                json,
+                other: try JSONYAMLConverter.convert(yaml, mode: .yamlToJSON)
+            )
+        }
+
+        func testJSONToYAML() throws {
+            let json = "{ a: 3 }"
+            let yaml = "a: 3\n"
+            AssertEqual(
+                yaml,
+                other: try JSONYAMLConverter.convert(json, mode: .jsonToYAML)
+            )
+        }
+    }
+#endif

--- a/Sources/DevToysApp/Pages/Converters/JSONYAMLConverterView.swift
+++ b/Sources/DevToysApp/Pages/Converters/JSONYAMLConverterView.swift
@@ -2,8 +2,11 @@ import SwiftUI
 
 struct JSONYAMLConverterView {
     @Environment(\.horizontalSizeClass) private var hSizeClass
-    @State private var input = ""
-    @State private var output = ""
+    @ObservedObject private var state: JSONYAMLConverterViewState
+
+    init(state: AppState) {
+        self.state = state.jsonYAMLConverterViewState
+    }
 }
 
 extension JSONYAMLConverterView: View {
@@ -16,9 +19,10 @@ extension JSONYAMLConverterView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } content: {
-                    Picker("", selection: .constant(0)) {
-                        Text("YAML to JSON").tag(0)
-                        Text("JSON to YAML").tag(1)
+                    Picker("", selection: self.$state.conversionMode) {
+                        ForEach(JSONYAMLConversionMode.allCases, id: \.self) {
+                            Text(LocalizedStringKey($0.description))
+                        }
                     }
                     .labelsHidden()
                 }
@@ -46,20 +50,20 @@ extension JSONYAMLConverterView: View {
 
     private var inputSection: some View {
         ToySection("Input") {
-            PasteButton(text: self.$input)
-            OpenFileButton(text: self.$input)
-            ClearButton(text: self.$input)
+            PasteButton(text: self.$state.input)
+            OpenFileButton(text: self.$state.input)
+            ClearButton(text: self.$state.input)
         } content: {
-            CodeEditor(text: self.$input)
+            CodeEditor(text: self.$state.input)
                 .frame(idealHeight: 200)
         }
     }
 
     private var outputSection: some View {
         ToySection("Output") {
-            CopyButton(text: self.output)
+            CopyButton(text: self.state.output)
         } content: {
-            CodeEditor(text: .constant(self.output))
+            CodeEditor(text: .constant(self.state.output))
                 .frame(idealHeight: 200)
         }
     }
@@ -68,7 +72,7 @@ extension JSONYAMLConverterView: View {
 struct JSONYAMLConverterView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
-            JSONYAMLConverterView()
+            JSONYAMLConverterView(state: .init())
         }
         .previewPresets()
     }

--- a/Sources/DevToysApp/Pages/Converters/JSONYAMLConverterViewState.swift
+++ b/Sources/DevToysApp/Pages/Converters/JSONYAMLConverterViewState.swift
@@ -16,16 +16,7 @@ final class JSONYAMLConverterViewState {
     @Published var output = ""
 
     private func updateOutput() {
-        guard let inputObject = try? UniYAML.decode(self.input) else {
-            self.output = ""
-            return
-        }
-        switch self.conversionMode {
-        case .yamlToJSON:
-            self.output = (try? UniYAML.encode(inputObject, with: .json)) ?? ""
-        case .jsonToYAML:
-            self.output = (try? UniYAML.encode(inputObject, with: .yaml)) ?? ""
-        }
+        self.output = (try? JSONYAMLConverter.convert(self.input, mode: self.conversionMode)) ?? ""
     }
 }
 

--- a/Sources/DevToysApp/Pages/Converters/JSONYAMLConverterViewState.swift
+++ b/Sources/DevToysApp/Pages/Converters/JSONYAMLConverterViewState.swift
@@ -1,0 +1,32 @@
+import Combine
+import UniYAML
+
+@MainActor
+final class JSONYAMLConverterViewState {
+    @Published var conversionMode = JSONYAMLConversionMode.yamlToJSON {
+        didSet {
+            if oldValue != self.conversionMode {
+                self.input = self.output
+            }
+        }
+    }
+    @Published var input = "" {
+        didSet { self.updateOutput() }
+    }
+    @Published var output = ""
+
+    private func updateOutput() {
+        guard let inputObject = try? UniYAML.decode(self.input) else {
+            self.output = ""
+            return
+        }
+        switch self.conversionMode {
+        case .yamlToJSON:
+            self.output = (try? UniYAML.encode(inputObject, with: .json)) ?? ""
+        case .jsonToYAML:
+            self.output = (try? UniYAML.encode(inputObject, with: .yaml)) ?? ""
+        }
+    }
+}
+
+extension JSONYAMLConverterViewState: ObservableObject {}

--- a/Sources/DevToysApp/Tool.swift
+++ b/Sources/DevToysApp/Tool.swift
@@ -178,7 +178,7 @@ enum Tool: String {
         case .hashGenerator: HashGeneratorView(state: state)
         case .htmlCoder: HTMLCoderView(state: state)
         case .jsonFormatter: JSONFormatterView(state: state)
-        case .jsonYAMLConverter: JSONYAMLConverterView()
+        case .jsonYAMLConverter: JSONYAMLConverterView(state: state)
         case .jwtDecoder: JWTDecoderView(state: state)
         case .loremIpsumGenerator: LoremIpsumGeneratorView(state: state)
         case .markdownPreview: MarkdownPreviewView(state: state)


### PR DESCRIPTION
Closes #1

If Swift Playgrounds become able to use Yams in the future, I will use it instead of UniYAML to complete implementation.