### PR TITLE
Update .swift-format to 509.0.0

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -13,10 +13,17 @@
   "lineBreakBeforeEachGenericRequirement" : true,
   "lineLength" : 120,
   "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+      "XCTAssertNoThrow"
+    ]
+  },
   "prioritizeKeepingFunctionOutputTogether" : false,
   "respectsExistingLineBreaks" : true,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : true,
+    "AlwaysUseLiteralForEmptyCollectionInit" : true,
     "AlwaysUseLowerCamelCase" : true,
     "AmbiguousTrailingClosureOverload" : true,
     "BeginDocumentationCommentWithOneLineSummary" : true,
@@ -37,12 +44,16 @@
     "NoLabelsInCasePatterns" : true,
     "NoLeadingUnderscores" : true,
     "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
     "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : true,
     "OneCasePerLine" : true,
     "OneVariableDeclarationPerLine" : true,
     "OnlyOneTrailingClosureArgument" : true,
     "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
     "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
     "UseEarlyExits" : true,
     "UseLetInEveryBoundCaseVariable" : true,
     "UseShorthandTypeNames" : true,

--- a/.swift-format
+++ b/.swift-format
@@ -19,7 +19,7 @@
       "XCTAssertNoThrow"
     ]
   },
-  "prioritizeKeepingFunctionOutputTogether" : false,
+  "prioritizeKeepingFunctionOutputTogether" : true,
   "respectsExistingLineBreaks" : true,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : true,


### PR DESCRIPTION
swift-format 509.0.0 is going to be released soon. I added new rules into `.swift-format` by comparing the previous one with the new one generated by `swift-format dump-configuration`.