### PR TITLE
fix: fix Base64 Coder

### DIFF
--- a/Sources/Models/Coders/Base64Coder.swift
+++ b/Sources/Models/Coders/Base64Coder.swift
@@ -1,16 +1,33 @@
 import struct Foundation.Data
 
-struct Base64Coder {
-    var encoding = String.Encoding.utf8
+enum Base64CoderEncoding {
+    case utf8
+    case ascii
 
-    func encode(_ input: String) -> String? {
-        input.data(using: self.encoding, allowLossyConversion: true)?
-            .base64EncodedString()
+    func encode(_ str: String) -> Data {
+        switch self {
+        case .utf8: Data(str.utf8)
+        case .ascii: Data(self.decode(Data(str.utf8)).utf8)
+        }
+    }
+
+    func decode(_ data: Data) -> String {
+        switch self {
+        case .utf8: String(decoding: data, as: UTF8.self)
+        case .ascii: String(decoding: data, as: Unicode.ASCII.self)
+        }
+    }
+}
+
+struct Base64Coder {
+    var encoding = Base64CoderEncoding.utf8
+
+    func encode(_ input: String) -> String {
+        self.encoding.encode(input).base64EncodedString()
     }
 
     func decode(_ input: String) -> String? {
-        Data(base64Encoded: input)
-            .flatMap { .init(data: $0, encoding: self.encoding) }
+        Data(base64Encoded: input).map(self.encoding.decode)
     }
 }
 
@@ -51,7 +68,7 @@ struct Base64Coder {
                 other: coder.encode("Hello there !")
             )
             AssertEqual(
-                "/w==",
+                "77+977+977+977+9",
                 other: coder.encode("🫃")
             )
         }
@@ -64,8 +81,8 @@ struct Base64Coder {
                 other: coder.decode("SGVsbG8gdGhlcmUgIQ==")
             )
             AssertEqual(
-                "?",
-                other: coder.decode("Pw==")
+                "������������",
+                other: coder.decode("77+977+977+977+9")
             )
         }
     }

--- a/Sources/Pages/Coders/Base64CoderView.swift
+++ b/Sources/Pages/Coders/Base64CoderView.swift
@@ -32,8 +32,8 @@ extension Base64CoderView: View {
                         .foregroundStyle(.secondary)
                 } content: {
                     Picker("", selection: self.$state.coder.encoding) {
-                        Text("UTF-8").tag(String.Encoding.utf8)
-                        Text("ASCII").tag(String.Encoding.ascii)
+                        Text("UTF-8").tag(Base64CoderEncoding.utf8)
+                        Text("ASCII").tag(Base64CoderEncoding.ascii)
                     }
                     .labelsHidden()
                 }

--- a/Sources/Pages/Coders/Base64CoderViewState.swift
+++ b/Sources/Pages/Coders/Base64CoderViewState.swift
@@ -20,7 +20,7 @@ final class Base64CoderViewState {
     private func updateOutput() {
         self.output =
             self.encodeMode
-            ? self.coder.encode(self.input) ?? ""
+            ? self.coder.encode(self.input)
             : self.coder.decode(self.input) ?? ""
     }
 }


### PR DESCRIPTION
I fixed the behavior of the Base64 Coder.

- Fixed so that the output does not become empty even when invalid characters are included
- Fixed the behavior when ASCII encoding is selected to match the behavior of the original DevToys

Test results:

<img width="3000" height="2300" alt="image" src="https://github.com/user-attachments/assets/e375ff3b-6b62-40ae-a2fe-00bcc8314a6d" />
