### PR TITLE
fix: fix CodeEditor minimum height in List Comparer

### DIFF
--- a/Sources/Pages/Text/ListComparerView.swift
+++ b/Sources/Pages/Text/ListComparerView.swift
@@ -36,6 +36,7 @@ extension ListComparerView: View {
                 CopyButton(text: self.state.output)
             } content: {
                 CodeEditor(text: .constant(self.state.output))
+                    .frame(idealHeight: 200)
             }
         }
         .navigationTitle(Tool.listComparer.strings.localizedLongTitle)
@@ -48,6 +49,7 @@ extension ListComparerView: View {
             ClearButton(text: self.$state.a)
         } content: {
             CodeEditor(text: self.$state.a)
+                .frame(idealHeight: 100)
         }
     }
 
@@ -58,6 +60,7 @@ extension ListComparerView: View {
             ClearButton(text: self.$state.b)
         } content: {
             CodeEditor(text: self.$state.b)
+                .frame(idealHeight: 100)
         }
     }
 }


### PR DESCRIPTION
fixes #160 

<img width="600" alt="IMG_0833" src="https://github.com/user-attachments/assets/732988ad-6079-4578-9b17-fe4edc91d6f3" />
<img height="300" alt="IMG_0834" src="https://github.com/user-attachments/assets/a7374889-dc2f-47cb-96e1-87f388a28e07" />
<img height="300" alt="IMG_0835" src="https://github.com/user-attachments/assets/2b4e4f4d-9727-490d-bd34-add68d42fc7e" />
