### PR TITLE
feat: add utility buttons to an image preview

### DIFF
--- a/Sources/Components/Buttons/CopyImageButton.swift
+++ b/Sources/Components/Buttons/CopyImageButton.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct CopyImageButton {
+    let image: UIImage
+    @ScaledMetric private var iconSize = 20
+}
+
+extension CopyImageButton: View {
+    var body: some View {
+        Button {
+            UIPasteboard.general.image = self.image
+        } label: {
+            Label {
+                Text("Copy")
+            } icon: {
+                Image(systemName: "doc.on.doc")
+                    .frame(width: self.iconSize, height: self.iconSize)
+            }
+            .labelStyle(.iconOnly)
+        }
+        .buttonStyle(.bordered)
+        .hoverEffect()
+    }
+}
+
+struct CopyImageButton_Previews: PreviewProvider {
+    static var previews: some View {
+        // swift-format-ignore: NeverForceUnwrap
+        CopyImageButton(
+            image: UIImage(systemName: "rainbow")!
+                .applyingSymbolConfiguration(.preferringMulticolor())!
+        )
+        .previewPresets()
+    }
+}

--- a/Sources/Components/Buttons/SaveImageButton.swift
+++ b/Sources/Components/Buttons/SaveImageButton.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct SaveImageButton {
+    let image: Image
+    @ScaledMetric private var iconSize = 20
+}
+
+extension SaveImageButton: View {
+    var body: some View {
+        ShareLink(item: self.image, preview: .init("image", image: self.image)) {
+            Label {
+                Text("Share")
+            } icon: {
+                Image(systemName: "square.and.arrow.up")
+                    .frame(width: self.iconSize, height: self.iconSize)
+            }
+            .labelStyle(.iconOnly)
+        }
+        .buttonStyle(.bordered)
+        .hoverEffect()
+    }
+}
+
+struct SaveImageButton_Previews: PreviewProvider {
+    static var previews: some View {
+        SaveImageButton(image: Image(systemName: "rainbow").symbolRenderingMode(.multicolor))
+            .previewPresets()
+    }
+}

--- a/Sources/Components/Buttons/ViewImageButton.swift
+++ b/Sources/Components/Buttons/ViewImageButton.swift
@@ -1,0 +1,56 @@
+import QuickLook
+import SwiftUI
+
+struct ViewImageButton {
+    let data: Data
+    @Environment(\.horizontalSizeClass) private var hSizeClass
+    @ScaledMetric private var iconSize = 20
+    @State private var imageURL: URL?
+    @State private var isSavingFailed = false
+}
+
+extension ViewImageButton: View {
+    var body: some View {
+        Button {
+            if let url = CIImage(data: self.data)?.cgImage?.save() {
+                self.imageURL = url
+            } else {
+                self.isSavingFailed = true
+            }
+        } label: {
+            if self.hSizeClass == .compact {
+                self.label.labelStyle(.iconOnly)
+            } else {
+                self.label
+            }
+        }
+        .buttonStyle(.bordered)
+        .hoverEffect()
+        .quickLookPreview(self.$imageURL)
+        .alert("Failed to view an image", isPresented: self.$isSavingFailed) {}
+    }
+
+    private var label: some View {
+        Label {
+            Text("View")
+        } icon: {
+            Image(systemName: "eye")
+                .frame(
+                    width: self.hSizeClass == .compact ? self.iconSize : nil,
+                    height: self.iconSize
+                )
+        }
+        .lineLimit(1)
+    }
+}
+
+struct ViewImageButton_Previews: PreviewProvider {
+    static var previews: some View {
+        // swift-format-ignore: NeverForceUnwrap
+        let data = Base64Coder.decode(
+            "R0lGODlhAQABAIAAAP7//wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=="
+        )!
+        return ViewImageButton(data: data)
+            .previewPresets()
+    }
+}

--- a/Sources/Extensions/CGImage+save.swift
+++ b/Sources/Extensions/CGImage+save.swift
@@ -1,0 +1,20 @@
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+
+extension CGImage {
+    func save() -> URL? {
+        guard
+            let uti = self.utType,
+            let ext = UTType(uti as String)?.preferredFilenameExtension
+        else { return nil }
+        let url = FileManager.default.temporaryDirectory
+            .appending(component: UUID().uuidString + "." + ext)
+        guard let destination = CGImageDestinationCreateWithURL(url as CFURL, uti, 1, nil) else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, self, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return url
+    }
+}

--- a/Sources/Pages/Coders/Base64ImageCoderView.swift
+++ b/Sources/Pages/Coders/Base64ImageCoderView.swift
@@ -21,12 +21,14 @@ extension Base64ImageCoderView: View {
                         .frame(idealHeight: 200)
                 }
                 ToySection("Image preview") {
-                    // TODO: Implement
-                    // CopyButton
-                    // SaveFileButton
+                    if let data = self.state.imageData, let image = UIImage(data: data) {
+                        ViewImageButton(data: data)
+                        CopyImageButton(image: image)
+                        SaveImageButton(image: Image(uiImage: image))
+                    }
                 } content: {
                     Group {
-                        if let data = self.state.imageData, let image = UIImage(data: data) {
+                        if let image = self.state.imageData.flatMap(UIImage.init) {
                             Image(uiImage: image).resizable().scaledToFit()
                         } else {
                             ContentUnavailableView("No Image", systemImage: "photo")


### PR DESCRIPTION
Closes #165

Utility buttons consist of "View", "Copy", and "Save" buttons.

<img width="800" alt="screenshot" src="https://github.com/user-attachments/assets/4bfc77c6-d7df-42aa-8e1a-d974c21d8fab" />
