### PR TITLE
build: limit swift-collections to versions below 1.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/Ink", from: "0.6.0"),
         .package(url: "https://github.com/kkebo/swift-uniyaml", branch: "master"),
         .package(url: "https://github.com/mchakravarty/CodeEditorView", from: "0.13.0"),
-        .package(url: "https://github.com/apple/swift-collections", from: "1.1.4"),
+        .package(url: "https://github.com/apple/swift-collections", "1.1.4"..<"1.4.0"),
         .package(url: "https://github.com/kkebo/export-ipa", from: "0.2.0"),
     ],
     targets: [


### PR DESCRIPTION
Swift Playground can't build swift-collections since swift-collections
1.4.0. That's because it has started using `package` keywords, which
requires the `-package-name` argument.