### PR TITLE
build: bump minimum deployment target to iOS 26

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import PackageDescription
 let package = Package(
     name: "DevToys.swiftpm",
     platforms: [
-        .iOS("18.1")
+        .iOS(.v26)
     ],
     products: [],
     dependencies: [

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ This app is a SwiftUI reimplementation of [DevToys](https://devtoys.app), a Swis
 
 ## Target platforms
 
-- iPadOS 18.1 or later
-- iOS 18.1 or later
+- iPadOS 26.0 or later
+- iOS 26.0 or later
   
 ## Build requirements
 
-- Swift Playground 4.7 or later (iPadOS 18.1 or later)
+- Swift Playground 4.7 or later (iPadOS 26.0 or later)
 - Swift Playground 4.7 or later (macOS 15.0 or later)
 - Xcode 26.0 or later (macOS 15.6 or later)
 


### PR DESCRIPTION
Swift Playground 4.7 includes Swift 6.2 and the SDK for iOS 26.